### PR TITLE
feat: add clear button to input field

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -104,6 +104,11 @@ h2 {
     margin-bottom: 1.5rem;
 }
 
+.input-wrapper {
+    position: relative;
+    width: 100%;
+}
+
 label {
     display: block;
     margin-bottom: 0.5rem;
@@ -128,6 +133,7 @@ textarea {
     width: 100%;
     min-height: 120px;
     padding: 1rem;
+    padding-right: 2.5rem;
     border: 2px solid #e1e1e1;
     border-radius: 6px;
     font-size: 1rem;
@@ -340,4 +346,41 @@ footer p:last-child {
 .char-counter.error {
     color: var(--error-color);
     font-weight: 600;
+}
+
+/* Clear Button */
+.clear-button {
+    position: absolute;
+    top: 0.75rem;
+    right: 0.75rem;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    background: rgba(0, 0, 0, 0.1);
+    color: #666;
+    border: none;
+    border-radius: 50%;
+    font-size: 1.5rem;
+    line-height: 1;
+    cursor: pointer;
+    display: none;
+    align-items: center;
+    justify-content: center;
+    transition: var(--transition);
+    z-index: 10;
+    font-weight: 300;
+}
+
+.clear-button.show {
+    display: flex;
+}
+
+.clear-button:hover {
+    background: rgba(0, 0, 0, 0.2);
+    color: var(--error-color);
+    transform: scale(1.1);
+}
+
+.clear-button:active {
+    transform: scale(0.95);
 }

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -7,6 +7,7 @@ logger.setLevel(
 document.addEventListener("DOMContentLoaded", function () {
   const textInput = document.getElementById("text");
   const charCounter = document.getElementById("charCounter");
+  const clearButton = document.getElementById("clearButton");
   const maxLength = 500;
 
   if (!textInput || !charCounter) return;
@@ -28,11 +29,36 @@ document.addEventListener("DOMContentLoaded", function () {
     }
   }
 
- 
-  updateCharCounter();
+  function toggleClearButton() {
+    if (clearButton) {
+      if (textInput.value.trim().length > 0) {
+        clearButton.classList.add("show");
+      } else {
+        clearButton.classList.remove("show");
+      }
+    }
+  }
 
- 
-  textInput.addEventListener("input", updateCharCounter);
+  function clearInput() {
+    textInput.value = "";
+    textInput.focus();
+    updateCharCounter();
+    toggleClearButton();
+  }
+
+  // Initialize
+  updateCharCounter();
+  toggleClearButton();
+
+  // Event listeners
+  textInput.addEventListener("input", function () {
+    updateCharCounter();
+    toggleClearButton();
+  });
+
+  if (clearButton) {
+    clearButton.addEventListener("click", clearInput);
+  }
 });
 
 document

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -37,16 +37,26 @@
         <form id="sentimentForm">
           <div class="form-group">
             <label for="text">Enter your text:</label>
-            <textarea
-              id="text"
-              name="text"
-              required
-              placeholder="Type something to analyze..."
-              autocomplete="off"
-              aria-label="Text input for sentiment analysis"
-              rows="4"
-              maxlength="500"
-            ></textarea>
+            <div class="input-wrapper">
+              <textarea
+                id="text"
+                name="text"
+                required
+                placeholder="Type something to analyze..."
+                autocomplete="off"
+                aria-label="Text input for sentiment analysis"
+                rows="4"
+                maxlength="500"
+              ></textarea>
+              <button
+                type="button"
+                class="clear-button"
+                id="clearButton"
+                aria-label="Clear text"
+              >
+                ×
+              </button>
+            </div>
             <div class="char-counter" id="charCounter" aria-live="polite">
               0 / 500 characters
             </div>


### PR DESCRIPTION
Closes #35 
@livingmangal 


https://github.com/user-attachments/assets/1c863509-d623-4ebb-a755-a67ba8adc9e8

I added a clear (X) button to the input field so users can quickly remove entered text without manual deletion. The button is only visible when the input contains text, improving usability without adding visual clutter. Clicking the button clears the input and returns focus to it, providing a smoother and more intuitive user interaction.
