### PR TITLE
Add copy to clipboard feature for sentiment results

### DIFF
--- a/app/static/css/style.css
+++ b/app/static/css/style.css
@@ -399,3 +399,24 @@ footer {
     from { opacity: 0; transform: translateY(20px); }
     to { opacity: 1; transform: translateY(0); }
 }
+/* Copy to Clipboard */
+#copyBtn {
+    padding: 6px 14px;
+    border-radius: 6px;
+    border: 1px solid var(--primary);
+    background: white;
+    color: var(--primary);
+    font-weight: 600;
+    cursor: pointer;
+}
+
+#copyBtn:hover {
+    background: var(--primary);
+    color: white;
+}
+
+#copyFeedback {
+    margin-left: 8px;
+    font-size: 0.85rem;
+    color: var(--success);
+}

--- a/app/static/js/script.js
+++ b/app/static/js/script.js
@@ -360,3 +360,23 @@ document.addEventListener("DOMContentLoaded", function () {
         });
     }
 });
+// ---- Copy to Clipboard (added feature) ----
+const copyContainer = document.getElementById("copyContainer");
+const copyBtn = document.getElementById("copyBtn");
+const copyFeedback = document.getElementById("copyFeedback");
+
+if (copyContainer) copyContainer.style.display = "block";
+
+if (copyBtn) {
+    copyBtn.onclick = async () => {
+        try {
+            await navigator.clipboard.writeText(
+                `${sentiment.toUpperCase()} (${confidence}%)`
+            );
+            copyFeedback.innerText = "Copied!";
+            setTimeout(() => copyFeedback.innerText = "", 1500);
+        } catch {
+            copyFeedback.innerText = "Copy failed";
+        }
+    };
+}

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -65,6 +65,12 @@
                         <h3>Ready to Analyze</h3>
                         <p>Your results will appear here with detailed confidence scoring.</p>
                     </div>
+
+                    <!-- Copy to Clipboard (added feature) -->
+                    <div style="margin-top: 12px; display: none;" id="copyContainer">
+                        <button id="copyBtn">Copy</button>
+                        <span id="copyFeedback"></span>
+                    </div>
                 </section>
             </div>
 


### PR DESCRIPTION
# Summary
This pull request adds a Copy to Clipboard feature to the sentiment analysis results, allowing users to quickly copy and reuse the analyzed output.

# Changes Made
- Added a *Copy* button next to the sentiment result
- Implemented clipboard functionality using the native Clipboard API
- Displayed user feedback on successful or failed copy actions
- Ensured error handling for unsupported or failed clipboard operations
- Kept all existing UI, logic, and analytics behavior unchanged

# Why This Change
Users may want to share or reuse sentiment analysis results externally. This enhancement improves usability and accessibility without introducing any breaking changes or refactoring existing code.

# Screenshots
(Attached showing the Copy button and successful copy feedback)

### Issue Reference
Closes #36
