### PR TITLE
Restrict CORS Origins in Production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,8 @@
+# Flask Environment
+FLASK_APP=main.py
+FLASK_ENV=development
+
+# Security
+# Comma-separated list of allowed domains. Use * for development.
+# Example: https://your-app.onrender.com,http://localhost:3000
+ALLOWED_ORIGINS=*

--- a/app/api.py
+++ b/app/api.py
@@ -52,10 +52,18 @@ app.config['SEND_FILE_MAX_AGE_DEFAULT'] = 0
 app.config['TEMPLATES_AUTO_RELOAD'] = True
 
 # Configure CORS
+# Get allowed origins from environment variable, default to "*" (allow all) for development
+allowed_origins_env = os.environ.get('ALLOWED_ORIGINS', '*')
+if allowed_origins_env != '*':
+    # Split comma-separated string into a list of origins
+    allowed_origins = [origin.strip() for origin in allowed_origins_env.split(',')]
+else:
+    allowed_origins = '*'
+
 CORS(app, 
      resources={
          r"/*": {
-             "origins": "*",
+             "origins": allowed_origins,
              "methods": ["GET", "POST", "OPTIONS"],
              "allow_headers": ["Content-Type", "Authorization", "Accept", "X-Session-ID"]
          }


### PR DESCRIPTION
## Description
This PR addresses issue #9 [SECURITY] Restrict CORS Origins in Production. 

Previously, the application was configured to allow Cross-Origin Resource Sharing (CORS) from all origins (`*`), which posed a security risk in production environments.

This update introduces a dynamic configuration for CORS:
- **Development:** Developers can default to `*` or specify localhost.
- **Production:** The allowed origins are strictly defined via the `ALLOWED_ORIGINS` environment variable, ensuring only trusted domains (like the frontend hosted on Render) can access the API.
---
### _Suggested Difficulty: Medium_
- @livingmangal 
---
## Changes Made
- Modified `app/api.py` to read allowed origins from the `ALLOWED_ORIGINS` environment variable.
- Created `.env.example` to document the new environment variable and provide a template for developers.

## How to Test
1. **Local Development (Default):**
   - Run the app without setting `ALLOWED_ORIGINS`.
   - Verify that requests from any origin (or localhost) still work (default behavior).

2. **Restricted Mode:**
   - Set the environment variable: `export ALLOWED_ORIGINS=https://trusted-site.com`
   - Run the app.
   - Attempt a request from a different origin (e.g., localhost) and verify it is blocked by CORS.
   - Attempt a request from `https://trusted-site.com` and verify it succeeds.

## Checklist
- [x] `app/api.py` updated with dynamic CORS logic.
- [x] `.env.example` added with `ALLOWED_ORIGINS` variable.
- [x] Verified that the application defaults to allow-all if the variable is not set (preserving dev experience).

## Deployment Notes
**Action Required:** After merging, please add the `ALLOWED_ORIGINS` environment variable to the production environment on Render.
- **Key:** `ALLOWED_ORIGINS`
- **Value:** `https://sentiment-analysis-project-oyz1.onrender.com` (or your specific frontend domain)